### PR TITLE
Returns icache interface with `NewS3FIFO` func

### DIFF
--- a/s3fifo.go
+++ b/s3fifo.go
@@ -19,7 +19,7 @@ type S3FIFO[K comparable, V any] struct {
 	ghost *bucketTable[K]
 }
 
-func NewS3FIFO[K comparable, V any](size int) *S3FIFO[K, V] {
+func NewS3FIFO[K comparable, V any](size int) Cache[K, V] {
 	return &S3FIFO[K, V]{
 		size:  size,
 		items: make(map[K]V),

--- a/types.go
+++ b/types.go
@@ -3,7 +3,7 @@ package fifo
 // Cache is the interface for a cache.
 type Cache[K comparable, V any] interface {
 	// Set sets the value for the given key on cache.
-	Set(key K, value V) bool
+	Set(key K, value V)
 
 	// Get gets the value for the given key from cache.
 	Get(key K) (value V, ok bool)


### PR DESCRIPTION
Fixed to return `Cache` interface instead of `S3FIFO` struct.