### PR TITLE
fix: runtime panic "index out of range" caused by nextCleanupBucket

### DIFF
--- a/sieve/sieve.go
+++ b/sieve/sieve.go
@@ -9,6 +9,10 @@ import (
 	"github.com/scalalang2/golang-fifo/types"
 )
 
+// numberOfBuckets is the number of buckets to store the cache entries
+//
+// Notice: if this number exceeds 256, the type of nextCleanupBucket
+// in the Sieve struct should be changed to int16
 const numberOfBuckets = 100
 
 // entry holds the key and value of a cache entry.
@@ -249,8 +253,8 @@ func (s *Sieve[K, V]) addToBucket(e *entry[K, V]) {
 	if s.ttl == 0 {
 		return
 	}
-	bucketId := (numberOfBuckets + s.nextCleanupBucket - 1) % numberOfBuckets
-	e.bucketID = bucketId
+	bucketId := (numberOfBuckets + int(s.nextCleanupBucket) - 1) % numberOfBuckets
+	e.bucketID = int8(bucketId)
 	s.buckets[bucketId].entries[e.key] = e
 	if s.buckets[bucketId].newestEntry.Before(e.expiredAt) {
 		s.buckets[bucketId].newestEntry = e.expiredAt

--- a/sieve/sieve_test.go
+++ b/sieve/sieve_test.go
@@ -205,8 +205,8 @@ func TestLargerWorkloadsThanCacheSize(t *testing.T) {
 		bytes []byte
 	}
 
-	cache := New[int32, value](128, 0)
-	workload := int32(256)
+	cache := New[int32, value](512, time.Millisecond)
+	workload := int32(10240)
 	for i := int32(0); i < workload; i++ {
 		val := value{
 			bytes: make([]byte, 10),


### PR DESCRIPTION
The type of `nextCleanupBucket` is `int8`, if the `size` is greater than `int8`, it will result in overflow causing negative numbers, ultimately leading to a program panic.

```
panic: runtime error: index out of range [-28]

goroutine 104 [running]:
github.com/scalalang2/golang-fifo/sieve.(*Sieve[...]).addToBucket(0xe3ae20, 0xc000496b90)
	/home/laisky.cai/go/pkg/mod/github.com/scalalang2/golang-fifo@v1.0.0/sieve/sieve.go:250 +0x3a7
github.com/scalalang2/golang-fifo/sieve.(*Sieve[...]).Set(0xe3ae20, {0xc000346468, 0x8}, {0xc000346478, 0x8})
	/home/laisky.cai/go/pkg/mod/github.com/scalalang2/golang-fifo@v1.0.0/sieve/sieve.go:117 +0xb91
```