### PR TITLE
Reduce dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,4 @@ module github.com/scalalang2/golang-fifo
 
 go 1.22
 
-require github.com/stretchr/testify v1.8.4
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
+require fortio.org/assert v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,2 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+fortio.org/assert v1.2.1 h1:48I39urpeDj65RP1KguF7akCjILNeu6vICiYMEysR7Q=
+fortio.org/assert v1.2.1/go.mod h1:039mG+/iYDPO8Ibx8TrNuJCm2T2SuhwRI3uL9nHTTls=

--- a/s3fifo/s3fifo_test.go
+++ b/s3fifo/s3fifo_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"fortio.org/assert"
 )
 
 const noEvictionTTL = 0
@@ -15,8 +15,8 @@ func TestSetAndGet(t *testing.T) {
 	cache.Set("hello", "world")
 
 	value, ok := cache.Get("hello")
-	require.True(t, ok)
-	require.Equal(t, "world", value)
+	assert.True(t, ok)
+	assert.Equal(t, "world", value)
 }
 
 func TestRemove(t *testing.T) {
@@ -24,19 +24,19 @@ func TestRemove(t *testing.T) {
 	cache.Set(1, 10)
 
 	val, ok := cache.Get(1)
-	require.True(t, ok)
-	require.Equal(t, 10, val)
+	assert.True(t, ok)
+	assert.Equal(t, 10, val)
 
 	// After removing the key, it should not be found
 	removed := cache.Remove(1)
-	require.True(t, removed)
+	assert.True(t, removed)
 
 	_, ok = cache.Get(1)
-	require.False(t, ok)
+	assert.False(t, ok)
 
 	// This should not panic
 	removed = cache.Remove(-1)
-	require.False(t, removed)
+	assert.False(t, removed)
 }
 
 func TestEvictOneHitWonders(t *testing.T) {
@@ -55,14 +55,14 @@ func TestEvictOneHitWonders(t *testing.T) {
 	// hit one-hit wonders only once
 	for _, v := range oneHitWonders {
 		_, ok := cache.Get(v)
-		require.True(t, ok)
+		assert.True(t, ok)
 	}
 
 	// hit the popular objects
 	for i := 0; i < 3; i++ {
 		for _, v := range popularObjects {
 			_, ok := cache.Get(v)
-			require.True(t, ok)
+			assert.True(t, ok)
 		}
 	}
 
@@ -74,13 +74,13 @@ func TestEvictOneHitWonders(t *testing.T) {
 
 	for _, v := range oneHitWonders {
 		_, ok := cache.Get(v)
-		require.False(t, ok)
+		assert.False(t, ok)
 	}
 
 	// popular objects should still be in the cache
 	for _, v := range popularObjects {
 		_, ok := cache.Get(v)
-		require.True(t, ok)
+		assert.True(t, ok)
 	}
 }
 
@@ -97,8 +97,8 @@ func TestPeek(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		for _, v := range entries {
 			value, exist := cache.Peek(v)
-			require.True(t, exist)
-			require.Equal(t, v*10, value)
+			assert.True(t, exist)
+			assert.Equal(t, v*10, value)
 		}
 	}
 
@@ -112,7 +112,7 @@ func TestPeek(t *testing.T) {
 	// they should not exist in the cache
 	for _, v := range entries {
 		_, exist := cache.Peek(v)
-		require.False(t, exist)
+		assert.False(t, exist)
 	}
 }
 
@@ -126,11 +126,11 @@ func TestContains(t *testing.T) {
 
 	// check if each entry exists in the cache
 	for _, v := range entries {
-		require.True(t, cache.Contains(v))
+		assert.True(t, cache.Contains(v))
 	}
 
 	for i := 6; i <= 10; i++ {
-		require.False(t, cache.Contains(i))
+		assert.False(t, cache.Contains(i))
 	}
 }
 
@@ -138,15 +138,15 @@ func TestLength(t *testing.T) {
 	cache := New[string, string](10, noEvictionTTL)
 
 	cache.Set("hello", "world")
-	require.Equal(t, 1, cache.Len())
+	assert.Equal(t, 1, cache.Len())
 
 	cache.Set("hello2", "world")
 	cache.Set("hello", "changed")
-	require.Equal(t, 2, cache.Len())
+	assert.Equal(t, 2, cache.Len())
 
 	value, ok := cache.Get("hello")
-	require.True(t, ok)
-	require.Equal(t, "changed", value)
+	assert.True(t, ok)
+	assert.Equal(t, "changed", value)
 }
 
 func TestClean(t *testing.T) {
@@ -156,15 +156,15 @@ func TestClean(t *testing.T) {
 	for _, v := range entries {
 		cache.Set(v, v*10)
 	}
-	require.Equal(t, 5, cache.Len())
+	assert.Equal(t, 5, cache.Len())
 	cache.Purge()
 
 	// check if each entry exists in the cache
 	for _, v := range entries {
 		_, exist := cache.Peek(v)
-		require.False(t, exist)
+		assert.False(t, exist)
 	}
-	require.Equal(t, 0, cache.Len())
+	assert.Equal(t, 0, cache.Len())
 }
 
 func TestTimeToLive(t *testing.T) {
@@ -175,8 +175,8 @@ func TestTimeToLive(t *testing.T) {
 	for num := 1; num <= numberOfEntries; num++ {
 		cache.Set(num, num)
 		val, ok := cache.Get(num)
-		require.True(t, ok)
-		require.Equal(t, num, val)
+		assert.True(t, ok)
+		assert.Equal(t, num, val)
 	}
 
 	time.Sleep(ttl * 2)
@@ -184,7 +184,7 @@ func TestTimeToLive(t *testing.T) {
 	// check all entries are evicted
 	for num := 1; num <= numberOfEntries; num++ {
 		_, ok := cache.Get(num)
-		require.False(t, ok)
+		assert.False(t, ok)
 	}
 }
 
@@ -206,8 +206,8 @@ func TestEvictionCallback(t *testing.T) {
 
 	// check the first object is evicted
 	_, ok := cache.Get(1)
-	require.False(t, ok)
-	require.Equal(t, 1, evicted[1])
+	assert.False(t, ok)
+	assert.Equal(t, 1, evicted[1])
 
 	cache.Close()
 }
@@ -237,7 +237,7 @@ func TestEvictionCallbackWithTTL(t *testing.T) {
 			mu.Lock()
 			if len(evicted) == 10 {
 				for i := 1; i <= 10; i++ {
-					require.Equal(t, i, evicted[i])
+					assert.Equal(t, i, evicted[i])
 				}
 				return
 			}

--- a/sieve/sieve_test.go
+++ b/sieve/sieve_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"fortio.org/assert"
 )
 
 const noEvictionTTL = 0
@@ -20,8 +20,8 @@ func TestGetAndSet(t *testing.T) {
 
 	for _, v := range items {
 		val, ok := cache.Get(v)
-		require.True(t, ok)
-		require.Equal(t, v*10, val)
+		assert.True(t, ok)
+		assert.Equal(t, v*10, val)
 	}
 
 	cache.Close()
@@ -32,19 +32,19 @@ func TestRemove(t *testing.T) {
 	cache.Set(1, 10)
 
 	val, ok := cache.Get(1)
-	require.True(t, ok)
-	require.Equal(t, 10, val)
+	assert.True(t, ok)
+	assert.Equal(t, 10, val)
 
 	// After removing the key, it should not be found
 	removed := cache.Remove(1)
-	require.True(t, removed)
+	assert.True(t, removed)
 
 	_, ok = cache.Get(1)
-	require.False(t, ok)
+	assert.False(t, ok)
 
 	// This should not panic
 	removed = cache.Remove(-1)
-	require.False(t, removed)
+	assert.False(t, removed)
 
 	cache.Close()
 }
@@ -65,7 +65,7 @@ func TestSievePolicy(t *testing.T) {
 	// hit popular objects
 	for _, v := range popularObjects {
 		_, ok := cache.Get(v)
-		require.True(t, ok)
+		assert.True(t, ok)
 	}
 
 	// add another objects to the cache
@@ -76,7 +76,7 @@ func TestSievePolicy(t *testing.T) {
 	// check popular objects are not evicted
 	for _, v := range popularObjects {
 		_, ok := cache.Get(v)
-		require.True(t, ok)
+		assert.True(t, ok)
 	}
 
 	cache.Close()
@@ -84,27 +84,27 @@ func TestSievePolicy(t *testing.T) {
 
 func TestContains(t *testing.T) {
 	cache := New[string, string](10, noEvictionTTL)
-	require.False(t, cache.Contains("hello"))
+	assert.False(t, cache.Contains("hello"))
 
 	cache.Set("hello", "world")
-	require.True(t, cache.Contains("hello"))
+	assert.True(t, cache.Contains("hello"))
 
 	cache.Close()
 }
 
 func TestLen(t *testing.T) {
 	cache := New[int, int](10, noEvictionTTL)
-	require.Equal(t, 0, cache.Len())
+	assert.Equal(t, 0, cache.Len())
 
 	cache.Set(1, 1)
-	require.Equal(t, 1, cache.Len())
+	assert.Equal(t, 1, cache.Len())
 
 	// duplicated keys only update the recent-ness of the key and value
 	cache.Set(1, 1)
-	require.Equal(t, 1, cache.Len())
+	assert.Equal(t, 1, cache.Len())
 
 	cache.Set(2, 2)
-	require.Equal(t, 2, cache.Len())
+	assert.Equal(t, 2, cache.Len())
 
 	cache.Close()
 }
@@ -113,10 +113,10 @@ func TestPurge(t *testing.T) {
 	cache := New[int, int](10, noEvictionTTL)
 	cache.Set(1, 1)
 	cache.Set(2, 2)
-	require.Equal(t, 2, cache.Len())
+	assert.Equal(t, 2, cache.Len())
 
 	cache.Purge()
-	require.Equal(t, 0, cache.Len())
+	assert.Equal(t, 0, cache.Len())
 
 	cache.Close()
 }
@@ -129,8 +129,8 @@ func TestTimeToLive(t *testing.T) {
 	for num := 1; num <= numberOfEntries; num++ {
 		cache.Set(num, num)
 		val, ok := cache.Get(num)
-		require.True(t, ok)
-		require.Equal(t, num, val)
+		assert.True(t, ok)
+		assert.Equal(t, num, val)
 	}
 
 	time.Sleep(ttl * 2)
@@ -138,7 +138,7 @@ func TestTimeToLive(t *testing.T) {
 	// check all entries are evicted
 	for num := 1; num <= numberOfEntries; num++ {
 		_, ok := cache.Get(num)
-		require.False(t, ok)
+		assert.False(t, ok)
 	}
 }
 
@@ -160,8 +160,8 @@ func TestEvictionCallback(t *testing.T) {
 
 	// check the first object is evicted
 	_, ok := cache.Get(1)
-	require.False(t, ok)
-	require.Equal(t, 1, evicted[1])
+	assert.False(t, ok)
+	assert.Equal(t, 1, evicted[1])
 
 	cache.Close()
 }
@@ -191,7 +191,7 @@ func TestEvictionCallbackWithTTL(t *testing.T) {
 			mu.Lock()
 			if len(evicted) == 10 {
 				for i := 1; i <= 10; i++ {
-					require.Equal(t, i, evicted[i])
+					assert.Equal(t, i, evicted[i])
 				}
 				return
 			}
@@ -214,7 +214,7 @@ func TestLargerWorkloadsThanCacheSize(t *testing.T) {
 		cache.Set(i, val)
 
 		v, ok := cache.Get(i)
-		require.True(t, ok)
-		require.Equal(t, v, val)
+		assert.True(t, ok)
+		assert.Equal(t, v, val)
 	}
 }


### PR DESCRIPTION
testify pulls in a lot of stuff and you only use a few asserts equal/true etc for which I have a drop in very light replacement (if you want) https://github.com/fortio/assert

ps: yes it's only for tests yet it impacts go.sum, downloads and ... running tests